### PR TITLE
Update rails app to have no local dependencies except docker

### DIFF
--- a/ruby/rails/Dockerfile
+++ b/ruby/rails/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.3.1
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN mkdir /myapp
+WORKDIR /myapp
+ADD Gemfile /myapp/Gemfile
+ADD Gemfile.lock /myapp/Gemfile.lock
+RUN bundle install
+ADD . /myapp
+

--- a/ruby/rails/Dockerfile
+++ b/ruby/rails/Dockerfile
@@ -1,9 +1,17 @@
 FROM ruby:2.3.1
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
-RUN mkdir /myapp
-WORKDIR /myapp
-ADD Gemfile /myapp/Gemfile
-ADD Gemfile.lock /myapp/Gemfile.lock
-RUN bundle install
-ADD . /myapp
 
+# install build-tools
+RUN apt-get update -qq \
+  && apt-get install -y \
+       build-essential \
+       libpq-dev \
+       nodejs
+
+# install application dependencies
+RUN mkdir /app
+WORKDIR /app
+ADD Gemfile /app
+ADD Gemfile.lock /app
+RUN bundle install
+
+CMD ["bundle", "exec", "unicorn", "-c", "config/unicorn.rb", "-l", "3000"]

--- a/ruby/rails/README.md
+++ b/ruby/rails/README.md
@@ -21,31 +21,16 @@ tracing compatibility issues with early versions of Rails.
 
 ## Getting started
 
-Launch backing services:
+Launch application:
 
-    docker-compose up -d
+    docker-compose up
 
-Set environment variables for POST permissions (Basic AUTH):
+In a second console:
 
-    export PROTECTED_USER=me
-    export PROTECTED_PASSWORD=123456
+    docker-compose run web rake db:create
+    docker-compose run web rake db:migrate
 
-Install dependencies and launch Unicorn:
+Back in the first console, stop docker with CTRL-C, then:
 
-    bundle install
-    bundle exec unicorn -c config/unicorn.rb
-
-or Passenger:
-
-    bundle exec passenger start
-
-## Available environment variables
-
-Set the following environment variables during the deploy:
-
-* ``RAILS_ENV=production``
-* ``SECRET_KEY_BASE``
-* ``DATABASE_URL``
-* ``REDIS_URL``
-* ``PROTECTED_USER``
-* ``PROTECTED_PASSWORD``
+    docker-compose stop
+    docker-compose up

--- a/ruby/rails/README.md
+++ b/ruby/rails/README.md
@@ -21,11 +21,12 @@ tracing compatibility issues with early versions of Rails.
 
 ## Getting started
 
-Launch application:
+Launch all services (it will trigger a Docker build):
 
     docker-compose up
 
-In a second console:
+When the MySQL service is up and running, launch in another console the following
+command to create the application database:
 
     docker-compose run web rake db:create
     docker-compose run web rake db:migrate
@@ -33,4 +34,13 @@ In a second console:
 Back in the first console, stop docker with CTRL-C, then:
 
     docker-compose stop
-    docker-compose up
+    DD_API_KEY=<your Datadog key> docker-compose up
+
+The above sends data to your Datadog account if the ``DD_API_KEY`` is valid.
+
+### Note about the build
+
+Dependencies listed in the ``Gemfile`` are installed at build time, so if you need to change
+them for any reason, remember to re-build the container via:
+
+    docker-compose build

--- a/ruby/rails/config/database.yml
+++ b/ruby/rails/config/database.yml
@@ -1,7 +1,7 @@
 # MySQL demo
 
 default: &default
-  host: 127.0.0.1
+  host: mysql
   adapter: mysql2
   username: root
   password: 123456

--- a/ruby/rails/config/environments/development.rb
+++ b/ruby/rails/config/environments/development.rb
@@ -1,4 +1,6 @@
 Blog::Application.configure do
+  config.secret_token = 'something_that_is_quite_long_but_not_secure'
+
   # Settings specified here will take precedence over those in config/application.rb
 
   # In the development environment your application's code is reloaded on

--- a/ruby/rails/config/initializers/datadog-tracer.rb
+++ b/ruby/rails/config/initializers/datadog-tracer.rb
@@ -9,5 +9,5 @@ Rails.configuration.datadog_trace = {
   default_database_service: ENV['RAILS_MYSQL_SERVICE'] || 'db-local',
   default_cache_service: ENV['RAILS_CACHE_SERVICE'] || 'cache-local',
   default_controller_service: ENV['RAILS_CONTROLLER_SERVICE'] || 'controller-local',
-  trace_agent_hostname: ENV['DATADOG_TRACER'] || 'localhost'
+  trace_agent_hostname: ENV['DATADOG_TRACER'] || 'datadog'
 }

--- a/ruby/rails/docker-compose.yml
+++ b/ruby/rails/docker-compose.yml
@@ -8,8 +8,33 @@ services:
         - MYSQL_PASSWORD=123456
         - MYSQL_USER=test
     ports:
-        - "127.0.0.1:3306:3306"
+        - "3306:3306"
   redis:
     image: redis:3.2
     ports:
-        - "127.0.0.1:6379:6379"
+        - "6379:6379"
+  web:
+    build: .
+    command: bundle exec unicorn -c config/unicorn.rb -l 3000
+    volumes:
+      - .:/myapp
+    ports:
+      - "3000:3000"
+    depends_on:
+      - mysql
+      - redis
+      - datadog
+    environment:
+      - PROTECTED_USER=me
+      - PROTECTED_PASSWORD=123456
+  datadog:
+    image: datadog/docker-dd-agent
+    ports:
+      - "8126:8126"
+    environment:
+     - API_KEY
+     - DD_APM_ENABLED=true
+    volumes:
+     - /var/run/docker.sock:/var/run/docker.sock
+     - /proc/mounts:/host/proc/mounts:ro
+     - /sys/fs/cgroup:/host/sys/fs/cgroup:ro

--- a/ruby/rails/docker-compose.yml
+++ b/ruby/rails/docker-compose.yml
@@ -15,9 +15,8 @@ services:
         - "6379:6379"
   web:
     build: .
-    command: bundle exec unicorn -c config/unicorn.rb -l 3000
     volumes:
-      - .:/myapp
+      - .:/app
     ports:
       - "3000:3000"
     depends_on:
@@ -29,12 +28,9 @@ services:
       - PROTECTED_PASSWORD=123456
   datadog:
     image: datadog/docker-dd-agent
-    ports:
-      - "8126:8126"
     environment:
-     - API_KEY
-     - DD_APM_ENABLED=true
-    volumes:
-     - /var/run/docker.sock:/var/run/docker.sock
-     - /proc/mounts:/host/proc/mounts:ro
-     - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
+        - DD_APM_ENABLED=true
+        - DD_BIND_HOST=0.0.0.0
+        - DD_API_KEY
+    ports:
+        - "8126:8126"


### PR DESCRIPTION
The original rails example required having a working local rails environment. I gave up getting that working on my mac. Since the example requires docker anyway, this PR sets everything to work from docker. Should be possible to get up and running on anyone's machine in minutes.