### PR TITLE
[apm] update dd-trace-rb version to 0.8.0

### DIFF
--- a/ruby/rails/Gemfile
+++ b/ruby/rails/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 ruby "2.3.1"
 
 # tracing
-gem 'ddtrace', :git => 'https://github.com/DataDog/dd-trace-rb.git', :ref => '12cdddbc3272bcbc4e4c650c222ee819da6947c2'
+gem 'ddtrace', '0.8.0'
 
 # rails
 gem 'rails', '3.2.22.4'
@@ -31,4 +31,4 @@ gem 'jquery-rails'
 gem 'unicorn', '4.8.3'
 
 # Use passenger as app server
-gem 'passenger', '5.0.28', require: "phusion_passenger/rack_handler"
+# gem 'passenger', '5.0.28', require: "phusion_passenger/rack_handler"

--- a/ruby/rails/Gemfile
+++ b/ruby/rails/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 ruby "2.3.1"
 
 # tracing
-gem 'ddtrace', '0.7.1.pre.944', :source => 'http://gems.datadoghq.com/trace-dev/'
+gem 'ddtrace', :git => 'https://github.com/DataDog/dd-trace-rb.git', :ref => '12cdddbc3272bcbc4e4c650c222ee819da6947c2'
 
 # rails
 gem 'rails', '3.2.22.4'

--- a/ruby/rails/Gemfile.lock
+++ b/ruby/rails/Gemfile.lock
@@ -1,6 +1,13 @@
+GIT
+  remote: https://github.com/DataDog/dd-trace-rb.git
+  revision: 12cdddbc3272bcbc4e4c650c222ee819da6947c2
+  ref: 12cdddbc3272bcbc4e4c650c222ee819da6947c2
+  specs:
+    ddtrace (0.7.3)
+      msgpack
+
 GEM
   remote: https://rubygems.org/
-  remote: http://gems.datadoghq.com/trace-dev/
   specs:
     actionmailer (3.2.22.4)
       actionpack (= 3.2.22.4)
@@ -49,8 +56,6 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     daemons (1.2.4)
-    ddtrace (0.7.1.pre.944)
-      msgpack
     delayed_job (4.1.2)
       activesupport (>= 3.0, < 5.1)
     delayed_job_active_record (4.1.1)
@@ -178,7 +183,7 @@ DEPENDENCIES
   activerecord-mysql-adapter
   coffee-rails (~> 3.2.1)
   daemons
-  ddtrace (= 0.7.1.pre.944)!
+  ddtrace!
   delayed_job_active_record
   grape
   jquery-rails

--- a/ruby/rails/Gemfile.lock
+++ b/ruby/rails/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 12cdddbc3272bcbc4e4c650c222ee819da6947c2
-  ref: 12cdddbc3272bcbc4e4c650c222ee819da6947c2
-  specs:
-    ddtrace (0.7.3)
-      msgpack
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -56,6 +48,8 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     daemons (1.2.4)
+    ddtrace (0.8.0)
+      msgpack
     delayed_job (4.1.2)
       activesupport (>= 3.0, < 5.1)
     delayed_job_active_record (4.1.1)
@@ -98,9 +92,6 @@ GEM
       mustermann (~> 1.0.0)
     mysql (2.9.1)
     mysql2 (0.3.21)
-    passenger (5.0.28)
-      rack
-      rake (>= 0.8.1)
     polyglot (0.3.5)
     rack (1.4.7)
     rack-accept (0.4.5)
@@ -183,12 +174,11 @@ DEPENDENCIES
   activerecord-mysql-adapter
   coffee-rails (~> 3.2.1)
   daemons
-  ddtrace!
+  ddtrace (= 0.8.0)
   delayed_job_active_record
   grape
   jquery-rails
   mysql2 (= 0.3.21)
-  passenger (= 5.0.28)
   rails (= 3.2.22.4)
   redis-rails
   sass-rails (~> 3.2.3)

--- a/ruby/sidekiq/Gemfile
+++ b/ruby/sidekiq/Gemfile
@@ -8,4 +8,4 @@ gem 'sinatra'
 gem 'sinatra-contrib'
 
 # tracing
-gem 'ddtrace', '0.7.1.pre.944', :source => 'http://gems.datadoghq.com/trace-dev/'
+gem 'ddtrace', :git => 'https://github.com/DataDog/dd-trace-rb.git', :ref => '12cdddbc3272bcbc4e4c650c222ee819da6947c2'

--- a/ruby/sidekiq/Gemfile
+++ b/ruby/sidekiq/Gemfile
@@ -8,4 +8,4 @@ gem 'sinatra'
 gem 'sinatra-contrib'
 
 # tracing
-gem 'ddtrace', :git => 'https://github.com/DataDog/dd-trace-rb.git', :ref => '12cdddbc3272bcbc4e4c650c222ee819da6947c2'
+gem 'ddtrace', '0.8.0'

--- a/ruby/sidekiq/Gemfile.lock
+++ b/ruby/sidekiq/Gemfile.lock
@@ -1,12 +1,17 @@
+GIT
+  remote: https://github.com/DataDog/dd-trace-rb.git
+  revision: 12cdddbc3272bcbc4e4c650c222ee819da6947c2
+  ref: 12cdddbc3272bcbc4e4c650c222ee819da6947c2
+  specs:
+    ddtrace (0.7.3)
+      msgpack
+
 GEM
   remote: https://rubygems.org/
-  remote: http://gems.datadoghq.com/trace-dev/
   specs:
     backports (3.6.8)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
-    ddtrace (0.7.1.pre.944)
-      msgpack
     json (2.0.3)
     msgpack (1.1.0)
     multi_json (1.12.1)
@@ -39,7 +44,7 @@ PLATFORMS
 
 DEPENDENCIES
   connection_pool
-  ddtrace (= 0.7.1.pre.944)!
+  ddtrace!
   json
   redis
   sidekiq

--- a/ruby/sidekiq/Gemfile.lock
+++ b/ruby/sidekiq/Gemfile.lock
@@ -1,17 +1,11 @@
-GIT
-  remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 12cdddbc3272bcbc4e4c650c222ee819da6947c2
-  ref: 12cdddbc3272bcbc4e4c650c222ee819da6947c2
-  specs:
-    ddtrace (0.7.3)
-      msgpack
-
 GEM
   remote: https://rubygems.org/
   specs:
     backports (3.6.8)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
+    ddtrace (0.8.0)
+      msgpack
     json (2.0.3)
     msgpack (1.1.0)
     multi_json (1.12.1)
@@ -44,7 +38,7 @@ PLATFORMS
 
 DEPENDENCIES
   connection_pool
-  ddtrace!
+  ddtrace (= 0.8.0)
   json
   redis
   sidekiq

--- a/ruby/sinatra/Gemfile
+++ b/ruby/sinatra/Gemfile
@@ -8,4 +8,4 @@ gem 'sinatra'
 gem 'sinatra-contrib'
 
 # tracing
-gem 'ddtrace', '0.7.1.pre.944', :source => 'http://gems.datadoghq.com/trace-dev/'
+gem 'ddtrace', :git => 'https://github.com/DataDog/dd-trace-rb.git', :ref => '12cdddbc3272bcbc4e4c650c222ee819da6947c2'

--- a/ruby/sinatra/Gemfile
+++ b/ruby/sinatra/Gemfile
@@ -8,4 +8,4 @@ gem 'sinatra'
 gem 'sinatra-contrib'
 
 # tracing
-gem 'ddtrace', :git => 'https://github.com/DataDog/dd-trace-rb.git', :ref => '12cdddbc3272bcbc4e4c650c222ee819da6947c2'
+gem 'ddtrace', '0.8.0'

--- a/ruby/sinatra/Gemfile.lock
+++ b/ruby/sinatra/Gemfile.lock
@@ -1,16 +1,10 @@
-GIT
-  remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 12cdddbc3272bcbc4e4c650c222ee819da6947c2
-  ref: 12cdddbc3272bcbc4e4c650c222ee819da6947c2
-  specs:
-    ddtrace (0.7.3)
-      msgpack
-
 GEM
   remote: https://rubygems.org/
   specs:
     backports (3.6.8)
     connection_pool (2.2.1)
+    ddtrace (0.8.0)
+      msgpack
     json (2.0.3)
     msgpack (1.1.0)
     multi_json (1.12.1)
@@ -38,7 +32,7 @@ PLATFORMS
 
 DEPENDENCIES
   connection_pool
-  ddtrace!
+  ddtrace (= 0.8.0)
   json
   redis
   sinatra

--- a/ruby/sinatra/Gemfile.lock
+++ b/ruby/sinatra/Gemfile.lock
@@ -1,11 +1,16 @@
+GIT
+  remote: https://github.com/DataDog/dd-trace-rb.git
+  revision: 12cdddbc3272bcbc4e4c650c222ee819da6947c2
+  ref: 12cdddbc3272bcbc4e4c650c222ee819da6947c2
+  specs:
+    ddtrace (0.7.3)
+      msgpack
+
 GEM
   remote: https://rubygems.org/
-  remote: http://gems.datadoghq.com/trace-dev/
   specs:
     backports (3.6.8)
     connection_pool (2.2.1)
-    ddtrace (0.7.1.pre.944)
-      msgpack
     json (2.0.3)
     msgpack (1.1.0)
     multi_json (1.12.1)
@@ -33,7 +38,7 @@ PLATFORMS
 
 DEPENDENCIES
   connection_pool
-  ddtrace (= 0.7.1.pre.944)!
+  ddtrace!
   json
   redis
   sinatra


### PR DESCRIPTION
### Overview

Since it has been released, we move from RC to the stable version 0.8.0