### PR TITLE
[go] added a simple heartbeat console program

### DIFF
--- a/go/heartbeat/main.go
+++ b/go/heartbeat/main.go
@@ -1,0 +1,34 @@
+package main
+
+// A simple program reporting very simple spans on a regular basis.
+
+import (
+	"context"
+	"time"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+const (
+	tickerDuration = time.Second
+	spanDuration   = time.Millisecond
+)
+
+func main() {
+	tracer.Start(tracer.WithDebugMode(true), tracer.WithServiceName("go-heartbeat"))
+	defer tracer.Stop()
+
+	ticker := time.NewTicker(tickerDuration)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		span, _ := tracer.StartSpanFromContext(
+			context.Background(),
+			"beat",
+			tracer.SpanType("custom"),
+			tracer.ResourceName("beat"),
+		)
+		time.Sleep(spanDuration)
+		span.Finish()
+	}
+}


### PR DESCRIPTION
I found this useful for simple tests, it has no dependency but the tracing library, and fires traces in the background. Technically I could have used a grpc daemon and *call* that daemon on a regular basis but this super simple program saves all this hassle.