### PR TITLE
[grpc] Fix required dependencies

### DIFF
--- a/python/grpc/requirements.txt
+++ b/python/grpc/requirements.txt
@@ -1,3 +1,4 @@
-grpc
-futures
 ddtrace
+futures
+googleapis-common-protos
+grpcio


### PR DESCRIPTION
We were installing the wrong `grpc` package and missing `googleapids-common-protos`.