### PR TITLE
Remove non existing test case from composer autoloader

### DIFF
--- a/php/Laravel42/composer.json
+++ b/php/Laravel42/composer.json
@@ -12,8 +12,7 @@
 			"app/controllers",
 			"app/models",
 			"app/database/migrations",
-			"app/database/seeds",
-			"app/tests/TestCase.php"
+			"app/database/seeds"
 		]
 	},
 	"scripts": {


### PR DESCRIPTION
A test class was present in composer autoloader declaration but was not existing anymore in code base. This caused an error during composer update.

This PR remove such file from the composer's autoload classmap.