### PR TITLE
[go] Cleanup of Go example bits.

### DIFF
--- a/distributed-tracing/api-gateway/frontend-go/main.go
+++ b/distributed-tracing/api-gateway/frontend-go/main.go
@@ -6,22 +6,15 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"net"
 	"net/http"
-	"os"
 
 	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 func main() {
-	// Get tracing config from environment variables.
-	agentHost := getEnvWithDefault("DD_AGENT_HOST", "localhost")
-	agentPort := getEnvWithDefault("DD_AGENT_PORT", "8126")
-	agentAddr := net.JoinHostPort(agentHost, agentPort)
-
-	// Configure the tracer
-	tracer.Start(tracer.WithAgentAddr(agentAddr), tracer.WithServiceName("frontend"))
+	// Initialize the tracer
+	tracer.Start()
 	defer tracer.Stop()
 
 	// Configure http client for api calls
@@ -38,7 +31,7 @@ func main() {
 }
 
 type quoteGenerator struct {
-	client *http.Client
+	client       *http.Client
 	bodyTemplate *template.Template
 }
 
@@ -82,12 +75,4 @@ func (q *quoteGenerator) fetchQuote(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return string(b), nil
-}
-
-func getEnvWithDefault(name string, defaultVal string) string {
-	val := os.Getenv(name)
-	if val == "" {
-		val = defaultVal
-	}
-	return val
 }

--- a/distributed-tracing/api-gateway/quotes-go/main.go
+++ b/distributed-tracing/api-gateway/quotes-go/main.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"log"
-	"net"
 	"net/http"
-	"os"
 	"time"
 
 	sqltrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql"
@@ -18,13 +15,8 @@ import (
 )
 
 func main() {
-	// Get tracing config from environment variables.
-	agentHost := getEnvWithDefault("DD_AGENT_HOST", "localhost")
-	agentPort := getEnvWithDefault("DD_AGENT_PORT", "8126")
-	agentAddr := net.JoinHostPort("%s:%s", agentHost, agentPort)
-
-	// Configure the tracer
-	tracer.Start(tracer.WithAgentAddr(agentAddr), tracer.WithServiceName("quotes"))
+	// Initialize the tracer
+	tracer.Start()
 	defer tracer.Stop()
 
 	// Configure sql tracing
@@ -56,10 +48,10 @@ func main() {
 	// Configure http service
 	mux := httptrace.NewServeMux(httptrace.WithServiceName("quotes"))
 	if connected {
-		log.Println("using random quotes");
+		log.Println("using random quotes")
 		mux.HandleFunc("/", randomQuote(db))
 	} else {
-		log.Println("using static quotes");
+		log.Println("using static quotes")
 		mux.HandleFunc("/", staticQuotes)
 	}
 
@@ -94,13 +86,4 @@ func staticQuotes(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(quote))
-}
-
-
-func getEnvWithDefault(name string, defaultVal string) string {
-	val := os.Getenv(name)
-	if val == "" {
-		val = defaultVal
-	}
-	return val
 }


### PR DESCRIPTION
The `getEnvWithDefault` bits were from older code, but got a bit copy-pasted.
The go tracer has since been changed to use the `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` environment variables as standard.