### PR TITLE
update django to new integration

### DIFF
--- a/python/django-tutorial-docker/requirements.txt
+++ b/python/django-tutorial-docker/requirements.txt
@@ -1,3 +1,3 @@
-ddtrace
+git+https://github.com/datadog/dd-trace-py@598afbca483a59c7178ac010836d82dd38869140#egg=ddtrace
 Django
 psycopg2


### PR DESCRIPTION
Updating to https://github.com/DataDog/dd-trace-py/pull/1161 automatically maps existing `settings.py` to new configuration approach.

New integration:

![image](https://user-images.githubusercontent.com/155673/74188969-8e193280-4c1d-11ea-8963-0ecc52689412.png)