### PR TITLE
apm(python): sanic automatic instrumentation example

### DIFF
--- a/python/sanic/Dockerfile
+++ b/python/sanic/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.8.0
+USER root
+WORKDIR /app
+ADD . /app
+RUN pip install --trusted-host pypi.python.org -r requirements.txt
+CMD ["ddtrace-run", "python", "app.py"]

--- a/python/sanic/README.md
+++ b/python/sanic/README.md
@@ -1,0 +1,32 @@
+# [Sanic](https://sanic.readthedocs.io/en/latest/index.html) Example App
+
+This is an example sanic app to instrument the application as well as for testing purposes.
+
+## Code Requirements
+
+- <a href="https://docs.datadoghq.com/agent/basic_agent_usage/?tab=agentv6v7">datadog-agent</a>, 
+- <a href="https://docs.datadoghq.com/tracing/setup/python/">datadog-tracing-library</a> & 
+- <a href="https://sanic.readthedocs.io/en/latest/index.html">sanic</a>
+
+The best way to get started is to clone this repo and run:
+
+### Execution Option 1:
+
+If you already have datadog agent running, you could run: ```ddtrace-run python basic_app.py```.
+
+### Execution Option 2:
+
+```
+docker-compose build --no-cache
+docker-compose up
+```
+
+Then open your browser to http://0.0.0.0:<your_port>/
+
+### Implementations:
+
+- Basic request and response traces would look like:
+
+![](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/6qu260YR/Image%202020-07-22%20at%2012.25.34%20PM.png?v=88a7c0746edd328bfc44f7313e4b6c72)
+
+![](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/wbuW2Jz8/Image%202020-07-22%20at%2012.27.04%20PM.png?v=db356cda678401d10c4cd526e248fe5c)

--- a/python/sanic/README.md
+++ b/python/sanic/README.md
@@ -16,6 +16,8 @@ If you already have datadog agent running, you could run: ```ddtrace-run python 
 
 ### Execution Option 2:
 
+Note: before running ```docker-compose```, update the ```env_file``` (e.g: ```.bashrc```, ```.bash_profile```) which contains ```Datadog API key``` or specify API key as environment variable.
+
 ```
 docker-compose build --no-cache
 docker-compose up

--- a/python/sanic/basic_app.py
+++ b/python/sanic/basic_app.py
@@ -1,0 +1,26 @@
+from sanic import Sanic, request, response
+from sanic.response import json, html, text, HTTPResponse, json
+import os
+
+
+app = Sanic("Simple Sanic App")
+
+
+@app.route("/")
+async def test(request):
+    return json({"hello": "world"})
+
+
+@app.route("/html")
+async def test(request):
+    template = open(os.getcwd() + "/templates/index.html")
+    return html(template.read())
+
+
+@app.route("/text")
+async def test(request):
+    return text("This is Text Response.")
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0")

--- a/python/sanic/docker-compose.yml
+++ b/python/sanic/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+  datadog-agent:
+    image: datadog/agent:latest
+    env_file:
+      - ~/<your .bashrc or .bash_profile file>
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+    ports:
+      - 127.0.0.1:8126:8126/tcp
+    environment:
+      - DD_APM_ENABLED=true
+      - DD_APM_NON_LOCAL_TRAFFIC=true
+      - DD_LOG_LEVEL=INFO
+      - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
+      - DD_AC_EXCLUDE=name:datadog-agent
+  web:
+    build: .
+    volumes:
+      - ./app
+    ports:
+      - "5000:5000"
+    environment:
+      - DD_AGENT_HOST=datadog-agent
+      - DD_TRACE_ANALYTICS_ENABLED=true
+    depends_on:
+      - datadog-agent

--- a/python/sanic/requirements.txt
+++ b/python/sanic/requirements.txt
@@ -1,0 +1,2 @@
+sanic
+ddtrace

--- a/python/sanic/templates/index.html
+++ b/python/sanic/templates/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    Hi there! loading html response..
+</body>
+</html>


### PR DESCRIPTION
We don't currently support Sanic integration with the Python Tracer, but [PR has been created for sanic automatic instrumentation](https://github.com/DataDog/dd-trace-py/pull/1572). 

We could import the ddtrace library with sanic PR and instrument this basic sanic example. I have also included how traces would look like in [the UI in the readme section](https://github.com/DataDog/trace-examples/blob/sadip/sanic_example/python/sanic/README.md#implementations). 

