### PR TITLE
Bump up ddtrace in django example

### DIFF
--- a/python/django/django-realworld/django-realworld-example-app/requirements.txt
+++ b/python/django/django-realworld/django-realworld-example-app/requirements.txt
@@ -4,4 +4,4 @@ django-extensions==1.7.1
 djangorestframework==3.4.4
 PyJWT==1.4.2
 six==1.10.0
-ddtrace>=0.34.0
+ddtrace>=0.50.3

--- a/python/django/django-tutorial/requirements.txt
+++ b/python/django/django-tutorial/requirements.txt
@@ -1,3 +1,3 @@
 Django
 psycopg2
-ddtrace>=0.34.0
+ddtrace>=0.50.3


### PR DESCRIPTION
Bumped up to [ddtrace v0.50.3](https://github.com/DataDog/dd-trace-py/releases/tag/v0.50.3) in django example.