### PR TITLE
[profiling] Add example for haproxy / dual shipping.

### DIFF
--- a/profiling/haproxy-dd-profiling/.gitignore
+++ b/profiling/haproxy-dd-profiling/.gitignore
@@ -1,0 +1,1 @@
+docker.env

--- a/profiling/haproxy-dd-profiling/README.md
+++ b/profiling/haproxy-dd-profiling/README.md
@@ -1,0 +1,54 @@
+# Datadog Profiling --> Haproxy
+
+This repository contains an example of sending profiles from a simple python app through haproxy. We use docker compose to make reproducing the environment easier,
+but this setup should be applicable for other environments as well.
+
+To run from project root: 
+
+1. Create a file called "docker.env" in the project root. This file is not tracked by git because it will contain your API keys. 
+2. Put your API key into "docker.env" like below by replacing PLACEHOLDER with the API key:
+
+```
+DD_API_KEY=PLACEHOLDER
+```
+
+3. To configure dual shipping, insert another line to "docker.env" where you replace PLACEHOLDER with the API key for the different intake. Note: your API key will be different if you are shipping data to another datacenter (e.g. us + eu).
+
+```
+DD_API_KEY=PLACEHOLDER
+DD_APM_PROFILING_ADDITIONAL_ENDPOINTS: '{"http://proxy:3837/api/v2/profile": ["PLACEHOLDER"]}'
+```
+
+4. Run the command below in the project root to start services (note you may have to run `docker-compose up --build` while debugging to make sure new env vars are loaded).
+
+ ```
+ docker-compose up
+ ```
+ 
+ 
+ ## Debugging
+
+You can see the haproxy stats page by visiting `http://localhost:3833`, should look something like below. If data is being sent through the proxy, `profiles-forwarder-us` 
+show sessions and non-zero in/out bytes. If dual shipping is configured you should also see data for `profiles-forwarder-eu` and both of the backends.
+
+<img width="1858" alt="haproxy-stats-dual-shipping" src="https://user-images.githubusercontent.com/2456071/202285471-9a67ef38-585f-45c7-a2d1-1741159a030f.png">
+
+To make sure that the proper profiling config is set by exec-ing into the agent and printing out config:
+- `docker-compose exec -it datadog-agent bash` 
+- `agent config | grep -A 20 apm_config`
+
+
+
+## Other Resources
+### Datadog specific
+https://docs.datadoghq.com/agent/proxy/?tab=linux#haproxy
+https://docs.datadoghq.com/agent/guide/dual-shipping/?tab=apm#overview
+
+### Haproxy
+https://www.haproxy.com/blog/how-to-run-haproxy-with-docker/
+https://www.haproxy.com/blog/haproxy-ssl-termination/
+
+### Docker
+https://docs.datadoghq.com/agent/guide/compose-and-the-datadog-agent/
+https://github.com/DataDog/docker-compose-example
+https://docs.docker.com/compose/networking/

--- a/profiling/haproxy-dd-profiling/docker-compose.yml
+++ b/profiling/haproxy-dd-profiling/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3.0"
+
+services:
+  proxy:
+    image: haproxytech/haproxy-alpine:2.4
+    volumes: 
+      - ./:/usr/local/etc/haproxy:ro
+    ports:
+      - "3833:3833"
+    expose:
+      - "3836"
+      - "3837"
+  datadog-agent:
+    image: datadog/agent:latest
+    env_file:
+      - docker.env
+    environment:
+      DD_APM_ENABLED: 'true'
+      DD_APM_PROFILING_DD_URL: 'http://proxy:3836/api/v2/profile'
+      DD_APM_NON_LOCAL_TRAFFIC: 'true'
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
+    expose:
+      - "8126"
+    depends_on:
+      - proxy
+  pyfib:
+    build: ./pyfib
+    env_file:
+      - docker.env
+    environment:
+      DD_PROFILING_ENABLED: 'true'
+      DD_TRACE_DEBUG: 'true'
+      DD_SERVICE: 'pyfib-haproxy-test'
+      DD_AGENT_HOST: 'datadog-agent'
+    depends_on:
+      - datadog-agent
+

--- a/profiling/haproxy-dd-profiling/haproxy.cfg
+++ b/profiling/haproxy-dd-profiling/haproxy.cfg
@@ -1,0 +1,55 @@
+
+# Basic configuration
+global
+    log 127.0.0.1 local0
+    maxconn 4096
+    stats socket /tmp/haproxy
+
+resolvers my-dns
+    nameserver dns1 8.8.8.8:53
+
+# Some sane defaults
+defaults
+    log     global
+    option  dontlognull
+    retries 3
+    option  redispatch
+    timeout client 5s
+    timeout server 5s
+    timeout connect 5s
+
+# This declares a view into HAProxy statistics, on port 3833
+# You do not need credentials to view this page and you can
+# turn it off once you are done with setup.
+listen stats
+    bind *:3833
+    mode http
+    stats enable
+    stats uri /
+
+# This declares the endpoint where your Agents connects for
+# sending profiles (for example, the value of "apm_config.profiling_dd_url").
+frontend profiles-forwarder-us
+    bind *:3836
+    mode tcp
+    option tcplog 
+    default_backend datadog-profiles-us
+
+backend datadog-profiles-us
+    balance roundrobin
+    mode tcp 
+    server profiles intake.profile.datadoghq.com:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check resolvers my-dns init-addr none resolve-prefer ipv4 
+
+# This declares the endpoint where your Agents connects for
+# sending profiles (for example, the value of "apm_config.profiling_dd_url").
+frontend profiles-forwarder-eu
+    bind *:3837
+    mode tcp
+    option tcplog 
+    default_backend datadog-profiles-eu
+
+backend datadog-profiles-eu
+    balance roundrobin
+    mode tcp 
+    server profiles intake.profile.datadoghq.eu:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt check resolvers my-dns init-addr none resolve-prefer ipv4 
+

--- a/profiling/haproxy-dd-profiling/pyfib/Dockerfile
+++ b/profiling/haproxy-dd-profiling/pyfib/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.9
+
+COPY . /app
+WORKDIR /app
+RUN pip install -r requirements.txt
+
+CMD ["ddtrace-run", "python", "pythonfib.py"]

--- a/profiling/haproxy-dd-profiling/pyfib/pythonfib.py
+++ b/profiling/haproxy-dd-profiling/pyfib/pythonfib.py
@@ -1,0 +1,20 @@
+import random
+import ddtrace
+import time
+
+STARTED = time.ctime(time.time())
+
+print("Pythonfib started!!!")
+
+
+def fib(n):
+    if n <= 1:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)
+
+
+while True:
+    lst = [i for i in range(35, 41)]
+    n = random.choice(lst)
+    print("fib({}) = {} (Running since {})".format(n, fib(n), STARTED))

--- a/profiling/haproxy-dd-profiling/pyfib/requirements.txt
+++ b/profiling/haproxy-dd-profiling/pyfib/requirements.txt
@@ -1,0 +1,9 @@
+attrs==21.2.0
+click==8.0.1
+ddtrace==0.49.3
+MarkupSafe==2.0.1
+packaging==21.0
+protobuf==3.17.3
+pyparsing==2.4.7
+six==1.16.0
+tenacity==7.0.0


### PR DESCRIPTION
Hey 👋 would like to make this example setup public to share with customers who want an example of using profiling with a proxy or enabling dual shipping of profiles. Was recommended (in the open-source slack channel) to merge this example here, but let me know if you think it doesn't fit. Thanks!