### PR TITLE
Change otel-collector-config to use new settings

### DIFF
--- a/opentelemetry/docker-compose.yml
+++ b/opentelemetry/docker-compose.yml
@@ -2,13 +2,14 @@ version: "3"
 services:
   otel-collector:
     image: otel/opentelemetry-collector-contrib:latest
-    command: ["--config=/etc/otel-collector-config.yml", "--log-level=debug"]
+    command: ["--config=/etc/otel-collector-config.yml"]
     ports:
       - "55680:55680/tcp"
       - "55681:55681/tcp"
       - "55678:55678/tcp"
       - "14268:14268/tcp"
       - "4317:4317/tcp"
+      - "4318:4318/tcp"
       - "9411:9411/tcp"
     volumes:
       - ./otel-collector-config.yml:/etc/otel-collector-config.yml

--- a/opentelemetry/otel-collector-config.yml
+++ b/opentelemetry/otel-collector-config.yml
@@ -1,12 +1,18 @@
 extensions:
+
 receivers:
   otlp:
     protocols:
+       # specifying 0.0.0.0 allows the otel-collector to be accessed from the host machine as well
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
+
   jaeger:
     protocols:
       thrift_http:
+
   zipkin:
 
 processors:
@@ -14,21 +20,21 @@ processors:
     timeout: 10s
 
 exporters:
+  debug:
+    verbosity: detailed
+
   datadog/api:
     hostname: customhostname
-    version: v1
 
     # tags:
     #   - example:tag
 
     api:
       key: <YOUR_API_KEY>
-  logging:
-    logLevel: info
 
 service:
   pipelines:
     traces:
       receivers: [otlp, zipkin, jaeger]
       processors: [batch]
-      exporters: [datadog/api]
+      exporters: [debug, datadog/api]


### PR DESCRIPTION
This changes the `otel-collector-config.yml` to use new settings so it works with `latest` as of `0.113.0`. It also configures the OTLP addresses to be `0.0.0.0` so the collector can be used standalone from the host machine.

I stumbled upon this broken example when trying to test out some rust code, and the only thing worse than no example is a broken exapmple.